### PR TITLE
[WIP] Use `AbstractVector` in LKJ and LKJCholesky bijectors

### DIFF
--- a/src/bijectors/corr.jl
+++ b/src/bijectors/corr.jl
@@ -345,22 +345,28 @@ end
 
 Inverse link function for cholesky factor.
 """
-function _inv_link_chol_lkj(y)
+function _inv_link_chol_lkj(Y::AbstractMatrix)
     # TODO: Implement adjoint to support reverse-mode AD backends properly.
-    K = LinearAlgebra.checksquare(y)
+    K = LinearAlgebra.checksquare(Y)
 
-    w = similar(y)
+    W = similar(Y)
 
     @inbounds for j in 1:K
-        w[1, j] = 1
+        W[1, j] = 1
         for i in 2:j
-            z = tanh(y[i-1, j])
-            tmp = w[i-1, j]
-            w[i-1, j] = z * tmp
-            w[i, j] = tmp * sqrt(1 - z^2)
+            z = tanh(Y[i-1, j])
+            tmp = W[i-1, j]
+            W[i-1, j] = z * tmp
+            W[i, j] = tmp * sqrt(1 - z^2)
         end
         for i in (j+1):K
-            w[i, j] = 0
+            W[i, j] = 0
+        end
+    end
+
+    return W
+end
+
         end
     end
 

--- a/src/bijectors/corr.jl
+++ b/src/bijectors/corr.jl
@@ -401,3 +401,18 @@ function _logabsdetjac_inv_corr(Y::AbstractMatrix)
     end
     return result
 end
+
+function _logabsdetjac_inv_corr(y::AbstractVector)
+    K = _triu1_dim_from_length(length(y))
+
+    result = float(zero(eltype(y)))
+    for (i, y_i) in enumerate(y)
+        abs_y_i = abs(y_i)
+        row_idx = vec_to_triu1_row_index(i)
+        result += (K - row_idx + 1) * (
+            IrrationalConstants.logtwo - (abs_y_i + LogExpFunctions.log1pexp(-2 * abs_y_i))
+        )
+    end
+    return result
+end
+

--- a/src/bijectors/corr.jl
+++ b/src/bijectors/corr.jl
@@ -294,6 +294,30 @@ function _link_chol_lkj(W::AbstractMatrix)
     return z
 end
 
+function _link_chol_lkj(W::UpperTriangular)
+    K = LinearAlgebra.checksquare(W)
+    N = ((K-1)*K) ÷ 2   # {K \choose 2} free parameters
+
+    z = zeros(eltype(W), N)
+
+    # This block can't be integrated with loop below, because w[1,1] != 0.
+    idx = 1
+    @inbounds for j = 2:K
+        z[idx] = atanh(W[1, j])
+        idx += 1
+        tmp = sqrt(1 - W[1, j]^2)
+        for i in 2:(j-1)
+            p = W[i, j] / tmp
+            tmp *= sqrt(1 - p^2)
+            z[idx] = atanh(p)
+            idx += 1
+        end
+    end
+
+    return z
+end
+
+function _link_chol_lkj(W::LowerTriangular)
 """
     _inv_link_chol_lkj(y)
 

--- a/src/bijectors/corr.jl
+++ b/src/bijectors/corr.jl
@@ -173,6 +173,13 @@ end
 
 inverse(::typeof(vec_to_triu1)) = triu1_to_vec
 
+function vec_to_triu1_row_index(idx)
+    # Assumes that vector was saved in a column-major order
+    # and that vector is one-based indexed.
+    M = _triu1_dim_from_length(idx - 1)
+    return idx - (M*(M-1) ÷ 2)
+end
+
 """
     VecCorrBijector <: Bijector
 

--- a/src/bijectors/corr.jl
+++ b/src/bijectors/corr.jl
@@ -367,10 +367,26 @@ function _inv_link_chol_lkj(Y::AbstractMatrix)
     return W
 end
 
+function _inv_link_chol_lkj(y::AbstractVector)
+    # TODO: Implement adjoint to support reverse-mode AD backends properly.
+    K = _triu1_dim_from_length(length(y))
+
+    W = similar(y, K, K)
+    W .= zeros(eltype(y))
+
+    idx = 1
+    @inbounds for j in 1:K
+        W[1, j] = 1
+        for i in 2:j
+            z = tanh(y[idx])
+            idx += 1
+            tmp = W[i-1, j]
+            W[i-1, j] = z * tmp
+            W[i, j] = tmp * sqrt(1 - z^2)
         end
     end
 
-    return w
+    return W
 end
 
 function _logabsdetjac_chol_lkj(Y::AbstractMatrix)

--- a/src/bijectors/corr.jl
+++ b/src/bijectors/corr.jl
@@ -416,3 +416,21 @@ function _logabsdetjac_inv_corr(y::AbstractVector)
     return result
 end
 
+function _logabsdetjac_inv_chol(y::AbstractVector)
+    K = _triu1_dim_from_length(length(y))
+
+    result = float(zero(eltype(y)))
+    idx = 1
+    @inbounds for j in 2:K
+        tmp = zero(result)
+        for _ in 1:(j-1)
+            z = tanh(y[idx])
+            logz = log(1 - z^2)
+            tmp += logz
+            result += logz + (tmp / 2)
+            idx += 1
+        end
+    end
+
+    return result
+end

--- a/src/bijectors/corr.jl
+++ b/src/bijectors/corr.jl
@@ -318,6 +318,28 @@ function _link_chol_lkj(W::UpperTriangular)
 end
 
 function _link_chol_lkj(W::LowerTriangular)
+    K = LinearAlgebra.checksquare(W)
+    N = div((K-1)*K, 2)   # {K \choose 2} free parameters
+
+    z = zeros(eltype(W), N)
+
+    # This block can't be integrated with loop below, because w[1,1] != 0.
+    idx = 1
+    @inbounds for i = 2:K
+        z[idx] = atanh(W[i, 1])
+        idx += 1
+        tmp = sqrt(1 - W[i, 1]^2)
+        for j in 2:(i-1)
+            p = W[i, j] / tmp
+            tmp *= sqrt(1 - p^2)
+            z[idx] = atanh(p)
+            idx += 1
+        end
+    end
+
+    return z
+end
+
 """
     _inv_link_chol_lkj(y)
 

--- a/src/bijectors/corr.jl
+++ b/src/bijectors/corr.jl
@@ -270,21 +270,21 @@ and so
 
 which is the above implementation.
 """
-function _link_chol_lkj(w)
+function _link_chol_lkj(W::AbstractMatrix)
     # TODO: Implement adjoint to support reverse-mode AD backends properly.
-    K = LinearAlgebra.checksquare(w)
+    K = LinearAlgebra.checksquare(W)
 
-    z = similar(w) # z is also UpperTriangular. 
+    z = similar(W) # z is also UpperTriangular. 
     # Some zero filling can be avoided. Though diagnoal is still needed to be filled with zero.
 
-    # This block can't be integrated with loop below, because w[1,1] != 0.
+    # This block can't be integrated with loop below, because W[1,1] != 0.
     @inbounds z[1, 1] = 0
 
     @inbounds for j = 2:K
-        z[1, j] = atanh(w[1, j])
-        tmp = sqrt(1 - w[1, j]^2)
+        z[1, j] = atanh(W[1, j])
+        tmp = sqrt(1 - W[1, j]^2)
         for i in 2:(j-1)
-            p = w[i, j] / tmp
+            p = W[i, j] / tmp
             tmp *= sqrt(1 - p^2)
             z[i, j] = atanh(p)
         end

--- a/src/bijectors/corr.jl
+++ b/src/bijectors/corr.jl
@@ -78,7 +78,7 @@ function transform(ib::Inverse{CorrBijector}, y::AbstractMatrix{<:Real})
     return pd_from_upper(w)
 end
 
-logabsdetjac(::Inverse{CorrBijector}, Y::AbstractMatrix{<:Real}) = _logabsdetjac_chol_lkj(Y)
+logabsdetjac(::Inverse{CorrBijector}, Y::AbstractMatrix{<:Real}) = _logabsdetjac_inv_corr(Y)
 function logabsdetjac(b::CorrBijector, X::AbstractMatrix{<:Real})
     #=
     It may be more efficient if we can use un-contraint value to prevent call of b
@@ -389,7 +389,7 @@ function _inv_link_chol_lkj(y::AbstractVector)
     return W
 end
 
-function _logabsdetjac_chol_lkj(Y::AbstractMatrix)
+function _logabsdetjac_inv_corr(Y::AbstractMatrix)
     K = LinearAlgebra.checksquare(Y)
 
     result = float(zero(eltype(Y)))

--- a/src/bijectors/corr.jl
+++ b/src/bijectors/corr.jl
@@ -65,10 +65,10 @@ struct CorrBijector <: Bijector end
 
 with_logabsdet_jacobian(b::CorrBijector, x) = transform(b, x), logabsdetjac(b, x)
 
-function transform(b::CorrBijector, x::AbstractMatrix{<:Real})
-    w = upper_triangular(parent(cholesky(x).U))  # keep LowerTriangular until here can avoid some computation
+function transform(b::CorrBijector, X::AbstractMatrix{<:Real})
+    w = upper_triangular(parent(cholesky(X).U))  # keep LowerTriangular until here can avoid some computation
     r = _link_chol_lkj(w) 
-    return r + zero(x) 
+    return r + zero(X) 
     # This dense format itself is required by a test, though I can't get the point.
     # https://github.com/TuringLang/Bijectors.jl/blob/b0aaa98f90958a167a0b86c8e8eca9b95502c42d/test/transform.jl#L67
 end

--- a/src/transformed_distribution.jl
+++ b/src/transformed_distribution.jl
@@ -161,6 +161,10 @@ function _rand!(rng::AbstractRNG, td::MatrixTransformed, x::DenseMatrix{<:Real})
     x .= td.transform(x)
 end
 
+function rand(rng::AbstractRNG, td::TransformedDistribution{T}) where {T <: Union{LKJ, LKJCholesky}}
+    return td.transform(rand(rng, td.dist))
+end
+
 # utility stuff
 Distributions.params(td::Transformed) = Distributions.params(td.dist)
 function Base.maximum(td::UnivariateTransformed)

--- a/src/transformed_distribution.jl
+++ b/src/transformed_distribution.jl
@@ -109,6 +109,11 @@ function logpdf(td::MvTransformed{<:Dirichlet}, y::AbstractMatrix{<:Real})
     return logpdf(td.dist, mappedarray(x->x+ϵ, x)) + logjac
 end
 
+function logpdf(td::TransformedDistribution{T}, y::AbstractVector{<:Real}) where {T <: Union{LKJ, LKJCholesky}}
+    x, logjac = with_logabsdet_jacobian(inverse(td.transform), y)
+    return logpdf(td.dist, x) + logjac
+end
+
 function _logpdf(td::MvTransformed, y::AbstractVector{<:Real})
     x, logjac = with_logabsdet_jacobian(inverse(td.transform), y)
     return logpdf(td.dist, x) + logjac

--- a/src/transformed_distribution.jl
+++ b/src/transformed_distribution.jl
@@ -6,6 +6,7 @@ struct TransformedDistribution{D, B, V} <: Distribution{V, Continuous} where {D<
     TransformedDistribution(d::UnivariateDistribution, b) = new{typeof(d), typeof(b), Univariate}(d, b)
     TransformedDistribution(d::MultivariateDistribution, b) = new{typeof(d), typeof(b), Multivariate}(d, b)
     TransformedDistribution(d::MatrixDistribution, b) = new{typeof(d), typeof(b), Matrixvariate}(d, b)
+    TransformedDistribution(d::Distribution{CholeskyVariate}, b) = new{typeof(d), typeof(b), CholeskyVariate}(d, b)
 end
 
 # fields may contain nested numerical parameters

--- a/src/transformed_distribution.jl
+++ b/src/transformed_distribution.jl
@@ -77,7 +77,8 @@ bijector(d::LowerboundedDistribution) = bijector_lowerbounded(d)
 bijector(d::PDMatDistribution) = PDBijector()
 bijector(d::MatrixBeta) = PDBijector()
 
-bijector(d::LKJ) = CorrBijector()
+bijector(d::LKJ) = VecCorrBijector()
+bijector(d::LKJCholesky) = d.uplo === 'L' ? VecTrilBijector() : VecTriuBijector()
 
 ##############################
 # Distributions.jl interface #

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -13,3 +13,8 @@ upper_triangular(A::AbstractMatrix) = convert(typeof(A), UpperTriangular(A))
 
 pd_from_lower(X) = LowerTriangular(X) * LowerTriangular(X)'
 pd_from_upper(X) = UpperTriangular(X)' * UpperTriangular(X)
+
+cholesky_factor(X::AbstractMatrix) = cholesky(X).UL
+cholesky_factor(X::Cholesky) = X.UL
+cholesky_factor(X::UpperTriangular) = X
+cholesky_factor(X::LowerTriangular) = X

--- a/test/bijectors/corr.jl
+++ b/test/bijectors/corr.jl
@@ -1,5 +1,5 @@
 using Bijectors, DistributionsAD, LinearAlgebra, Test
-using Bijectors: VecCorrBijector, CorrBijector
+using Bijectors: VecCorrBijector, CorrBijector, VecTriuBijector, VecTrilBijector
 
 @testset "CorrBijector & VecCorrBijector" begin
     for d ∈ [1, 2, 5]
@@ -31,5 +31,31 @@ using Bijectors: VecCorrBijector, CorrBijector
         # Hence, we disable those tests.
         test_bijector(b, x; test_not_identity=d != 1, changes_of_variables_test=false)
         test_bijector(bvec, x; test_not_identity=d != 1, changes_of_variables_test=false)
+    end
+end
+
+@testset "VecTriuBijector & VecTrilBijector" begin
+    for d ∈ [2, 5]
+        for dist in [LKJCholesky(d, 1, 'U'), LKJCholesky(d, 1, 'L')]
+            b = bijector(dist)
+
+            b_lkj = VecCorrBijector()
+            x = rand(dist)
+            y = b(x)
+            y_lkj = b_lkj(x)
+
+            @test y ≈ y_lkj
+
+            binv = inverse(b)
+            xinv = binv(y)
+            binv_lkj = inverse(b_lkj)
+            xinv_lkj = binv_lkj(y_lkj)
+
+            @test xinv.U ≈ cholesky(xinv_lkj).U
+
+            # test_bijector is commented out for now, 
+            # as isapprox is not defined for ::Cholesky types (the domain of LKJCholesky)
+            # test_bijector(b, x; test_not_identity=d != 1, changes_of_variables_test=false)
+        end
     end
 end


### PR DESCRIPTION
Expands on [#246](https://github.com/TuringLang/Bijectors.jl/pull/246). 

- Use `::AbstractVector` in `VecCorrBijector` operations, so we won't need to transform to `::AbstractMatrix` and back when `transform`. 
- Add bijector for `LKJCholesky`. I believe this was missing and in practice it is the more efficient alternative when working with correlation matrices (avoids Cholesky decompositions on every call).  

In `LKJCholesky` there is control over the returned factor (`'U' -> UpperTriangular` or `'L' -> LowerTriangular`). I was wondering whether we want to respect the factor choice and always return the same triangular factor. If yes, we can use `VecTriuBijector` and `VecTrilBijector` to retain information about the original factor in `LKJCholesky` and return it. If no, we can always work with one type, e.g. `UpperTriangular`.

TO DO : 
- Add `ChainRulesCore.rrule`s for all link functions that work on `::AbstractVector`, defined in this PR. I have only added one rule for the forward link function, but `ChainRulesTestUtils.test_rrule` complains about type instability and value mismatch. When comparing the values returned by the pullback inside the closure of `rrule` against [the one defined for Zygote](https://github.com/TuringLang/Bijectors.jl/blob/637df3a5a1310149f3a57125ef864494972f7730/src/compat/zygote.jl#L244)  using standard `::Matrix{Float64}` I'm getting the same output though. I will have more of a look next week.
- Document how I ended up with `_logabsdetjac_inv_chol`, so it can be verified. This was based on the Stan manual pages for [correlation matrices](https://mc-stan.org/docs/reference-manual/correlation-matrix-transform.html#absolute-jacobian-determinant-of-the-correlation-matrix-inverse-transform) and [Cholesky factors of correlation matrices](https://mc-stan.org/docs/reference-manual/cholesky-factors-of-correlation-matrices-1).

Related to the second point, right above, in general it would be nice if we could test these analytical formulas for logabsdetjac derived by hand. I played around with it a bit, but couldn't come up with something.
